### PR TITLE
arch: cxd56xx: Fix IRQ control in cxd56_dmac.c

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_dmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_dmac.c
@@ -595,8 +595,6 @@ static int dma_setintrcallback(int ch, dma_callback_t func, void *data)
     g_dmach[ch].callback = func;
     g_dmach[ch].arg = data;
 
-    up_enable_irq(irq_map[ch]);
-
     return 0;
 }
 
@@ -607,8 +605,6 @@ static int dma_clearintrcallback(int ch)
 
     g_dmach[ch].callback = NULL;
     g_dmach[ch].arg = NULL;
-
-    up_disable_irq(irq_map[ch]);
 
     return 0;
 }
@@ -676,6 +672,7 @@ void weak_function up_dma_initialize(void)
   for (i = 0; i < NCHANNELS; i++)
     {
       g_dmach[i].chan = i;
+      up_enable_irq(irq_map[i]);
     }
 
   nxsem_init(&g_dmaexc, 0, 1);


### PR DESCRIPTION
Summary:
- This commit fixes IRQ control in the following use case
- The gs2200m Wi-Fi driver requests SPI-DMA to receive a packet.
- cxd56_dma.c enables IRQ for the SPI-DMA and start transfer.
- Then LCD driver requests SPI-DMA to display an image.
- These SPI-DMAs use different DMA channels but shares DMA controller.
- Also, they shares the same IRQ.
- When the first SPI-DMA finishes the transfer, it disables the IRQ.
- And if the second SPI-DMA finishes the transfer just after the IRQ disabled.
- The the second SPI-DMA will be in a deadlock condition.
- To resolve this issue, do not control IRQ during DMA transfer.
- Instead, up_enable_irq() is called in up_dma_initialize()

Impact:
- All use cases which use DMA

Testing:
- Tested with spresense:wifi with LCD

Signed-off-by: Masayuki Ishikawa <Masayuki.Ishikawa@jp.sony.com>>