### PR TITLE
libc/unistd: getopt: Use argc to end parsing

### DIFF
--- a/libs/libc/unistd/lib_getopt_common.c
+++ b/libs/libc/unistd/lib_getopt_common.c
@@ -401,7 +401,7 @@ int getopt_common(int argc, FAR char * const argv[],
 
           /* Check for the end of the argument list */
 
-          go->go_optptr = argv[go->go_optind];
+          go->go_optptr = go->go_optind < argc ? argv[go->go_optind] : NULL;
           if (!go->go_optptr)
             {
               /* There are no more arguments, we are finished */


### PR DESCRIPTION
The ``fwupdate`` example may occur the following problem without this patch.
https://github.com/sonydevworld/spresense/issues/324

This commit was already merged to incubator-nuttx.
https://github.com/apache/incubator-nuttx/pull/5004