### PR TITLE
Add critical section to scu one-shot sequencer

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_scu.c
+++ b/arch/arm/src/cxd56xx/cxd56_scu.c
@@ -940,8 +940,11 @@ static void seq_setstartphase(int sid, int phase)
 static void seq_startseq(int sid)
 {
   uint32_t val;
+  irqstate_t flags;
+  flags = enter_critical_section();
   val = getreg32(SCU_START_MODE0);
   putreg32(val | (1 << sid), SCU_START_MODE0);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************
@@ -958,8 +961,11 @@ static void seq_startseq(int sid)
 static void seq_stopseq(int sid)
 {
   uint32_t val;
+  irqstate_t flags;
+  flags = enter_critical_section();
   val = getreg32(SCU_START_MODE0);
   putreg32(val & ~(1 << sid), SCU_START_MODE0);
+  leave_critical_section(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Add critical section to scu one-shot sequencer

## Impact
Running one shot sequencer from a task with a different priority may stop SCU_START.

## Testing
Confirmed that there is no problem when calling from 3 tasks.
